### PR TITLE
Made compatible with Julia 0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
 Requests
 JSON
+Compat

--- a/src/Docker.jl
+++ b/src/Docker.jl
@@ -2,10 +2,11 @@ module Docker
 
 using Requests
 using JSON
+using Compat
 
 immutable DockerError
     status::Int
-    msg::ByteString
+    msg::Compat.String
 end
 
 const headers = Dict("Content-Type" => "application/json")
@@ -41,7 +42,7 @@ function create_container(
         "OpenStdin"     => openStdin,
         "AttachStdout"  => attachStdout,
         "AttachStderr"  => attachStderr,
-        "ExposedPorts"  => [string(dec(p),"/tcp") => Dict() for p in ports],
+        "ExposedPorts"  => Dict([Pair(string(dec(p),"/tcp"), Dict()) for p in ports]),
         "HostConfig"    => Dict(
             "Memory"       => memory,
             "CpusetCpus"   => cpuSets,


### PR DESCRIPTION
- Use 0.5 String over 0.4's ByteString
- Updated 0.4 dict comprehension to be compatible between 0.4 and 0.5