### PR TITLE
Return cmd as an array of strings

### DIFF
--- a/src/Docker.jl
+++ b/src/Docker.jl
@@ -35,7 +35,6 @@ function create_container(
 
     params = Dict(
         "Image" => image,
-        "Cmd" => collect(cmd.exec),
         "Tty" => tty,
         "AttachStdin"   => attachStdin,
         "OpenStdin"     => openStdin,
@@ -59,7 +58,7 @@ function create_container(
     end
 
     if !isempty(cmd.exec)
-        params["Cmd"] = cmd
+        params["Cmd"] = collect(cmd.exec)
     end
 
     if !isempty(pwd)


### PR DESCRIPTION
The params dict was successfully turning the Cmd into an array of strings but later that was being overridden by the Cmd object.

Supplying a custom command would cause an exception:
```
ERROR (unhandled task failure): Docker.DockerError(500,"json: cannot unmarshal object into Go value of type string\n")
```